### PR TITLE
change file type from wav to mp3

### DIFF
--- a/custom_components/tiktoktts/tts.py
+++ b/custom_components/tiktoktts/tts.py
@@ -107,7 +107,7 @@ class TikTokTTSProvider(Provider):
                 data = await request.read()
                 audio = json.loads(data.decode("utf8"))
                 data = base64.b64decode(audio["data"])
-                audiotype = "wav"
+                audiotype = "mp3"
 
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Timeout for TikTokTTS API")


### PR DESCRIPTION
This PR changes the reported file type from `wav` to `mp3`.
I just installed/used this integration for the first time so I don't know if something changed on the TikTok API side of things, I presume yes. If installed as-is, I get a nasty ffmpeg transcoding error ending with `invalid start code [255][243][196][196] in RIFF header pipe:: Invalid data found when processing input`. So I made my own request to TikTok and dissected the JSON data returned, thereby figuring out it's mp3 encoded.